### PR TITLE
Fix bbswitch video card enabling.

### DIFF
--- a/nvidia_power_manager/sbin/gpuswitcher
+++ b/nvidia_power_manager/sbin/gpuswitcher
@@ -35,8 +35,8 @@ rrmmod() {
 
 if [[ $1 == "on" ]]
 then
-    modprobe nvidia &>/dev/null
     tee /proc/acpi/bbswitch <<< ON &>/dev/null
+    modprobe nvidia &>/dev/null
 else
     # try modprobe -r first
     modprobe -r -a nvidia &>/dev/null


### PR DESCRIPTION
Reordered module loading and `bbswitch` card enabling.

With the new order bbswitch doesn't raise errors as it's able to correctly determine video card state.